### PR TITLE
Handle bytes id provided by queue

### DIFF
--- a/slimta/redisstorage/__init__.py
+++ b/slimta/redisstorage/__init__.py
@@ -27,14 +27,12 @@
 
 from __future__ import absolute_import
 
-import os
 import uuid
 import time
 
 from six.moves import cPickle
 
 import redis
-import gevent
 from gevent import socket
 
 from slimta.queue import QueueStorage


### PR DESCRIPTION
Slimta queue calls the storage pethod with a bytes id arg, which caused errors when concatenating with prefix.

Not sure this is the best approach, but it works fine.
